### PR TITLE
fix intrinsic functions.

### DIFF
--- a/src/llvm_intrin/intrin_funcs.jl
+++ b/src/llvm_intrin/intrin_funcs.jl
@@ -218,7 +218,7 @@ end
 @inline vcopysign(v::VecUnroll, s::UnsignedHW) = vabs(v)
 @inline vcopysign(v::VecUnroll{N,W,T}, s::NativeTypes) where {N,W,T} = VecUnroll(fmap(vcopysign, getfield(v, :data), vbroadcast(Val{W}(), s)))
 
-for f ∈ [:vmax, :vmax_fast, :vmin, :vmin_fast]
+for (f, fl) ∈ [(:vmax, :max), (:vmax_fast, :max_fast), (:vmin, :min), (:vmin_fast, :min_fast)]
     @eval begin
         @inline function $f(a::Union{FloatingTypes,Vec{<:Any,<:FloatingTypes}}, b::Union{FloatingTypes,Vec{<:Any,<:FloatingTypes}})
             c, d = promote(a, b)
@@ -234,6 +234,8 @@ for f ∈ [:vmax, :vmax_fast, :vmin, :vmin_fast]
         end
         @inline $f(v::Vec{W,<:IntegerTypesHW}, s::IntegerTypesHW) where {W} = $f(v, vbroadcast(Val{W}(), s))
         @inline $f(s::IntegerTypesHW, v::Vec{W,<:IntegerTypesHW}) where {W} = $f(vbroadcast(Val{W}(), s), v)
+        @inline $f(a::FloatingTypes, b::FloatingTypes) = Base.FastMath.$fl(a, b)
+        @inline $f(a::Integer, b::Integer) = Base.FastMath.$fl(a, b)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1070,6 +1070,19 @@ include("testsetup.jl")
             # test_acc(VectorizationBase.vlog2, log2, T, xx, 7)
         end
     end
+
+    # fix the stackoverflow error in `vmax_fast`, `vmax`, `vmin` and `vmin_fast` for floating types
+    @time @testset "fix stackoverflow for `vmax_fast` et al." begin
+        @test VectorizationBase.vmax_fast(1.0,3.0) === 3.0
+        @test VectorizationBase.vmax_fast(1,3) === 3
+        @test VectorizationBase.vmin_fast(1,3) === 1
+        @test VectorizationBase.vmin_fast(1.0,3.0) === 1.0
+        @test VectorizationBase.vmax(1.0,3.0) === 3.0
+        @test VectorizationBase.vmax(1,3) === 3
+        @test VectorizationBase.vmin(1,3) === 1
+        @test VectorizationBase.vmin(1.0,3.0) === 1.0
+    end
+
     # end
 end # @testset VectorizationBase
 


### PR DESCRIPTION
Define `vmax` et. al. for floating types and integers, so that integers et al. can work in TropicalGEMM.
Before this patch, calling these function would produce Stackoverflow error.

```julia
        @test VectorizationBase.vmax_fast(1.0,3.0) === 3.0
        @test VectorizationBase.vmax_fast(1,3) === 3
        @test VectorizationBase.vmin_fast(1,3) === 1
        @test VectorizationBase.vmin_fast(1.0,3.0) === 1.0
        @test VectorizationBase.vmax(1.0,3.0) === 3.0
        @test VectorizationBase.vmax(1,3) === 3
        @test VectorizationBase.vmin(1,3) === 1
        @test VectorizationBase.vmin(1.0,3.0) === 1.0
```