### PR TITLE
Update combat for ArrayInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SIMDTypes = "94e857df-77ce-4151-89e5-788b33177be4"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [compat]
-ArrayInterface = "3.1.2 - 3.1.23, 3.1.25"
+ArrayInterface = "3.1.2 - 3.1.23, 3.1.25, 3.2"
 CPUSummary = "0.1.1"
 HostCPUFeatures = "0.1.2"
 Hwloc = "2.0"


### PR DESCRIPTION
Not sure if this will work but lets try. This change is important since otherwise EllipsesNotation.jl cannot update to version 1.1.3 since it is hold back by VectorizationBase.