### PR TITLE
Add searchsortedlast and getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VectorizationBase"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.21.44"
+version = "0.21.45"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/special/misc.jl
+++ b/src/special/misc.jl
@@ -193,12 +193,12 @@ end
 @inline Base.lcm(a::AbstractSIMD, b::Real) = ((c, d) = promote(a, b); lcm(c, d))
 @inline Base.lcm(a::Real, b::AbstractSIMD) = ((c, d) = promote(a, b); lcm(c, d))
 
-@inline function Base.getindex(A::AbstractArray, i::AbstractSIMD...)
+@inline function Base.getindex(A::Array, i::AbstractSIMD...)
   vload(stridedpointer(A), i)
 end
 
 @inline Base.Sort.midpoint(lo::AbstractSIMDVector{W,I}, hi::AbstractSIMDVector{W,I}) where {W,I<:Integer} = lo + ((hi - lo) >>> 0x01)
-@inline function Base.searchsortedlast(v::AbstractVector, x::AbstractSIMDVector{W,I}, lo::T, hi::T, o::Base.Ordering) where {W,I,T<:Integer}
+@inline function Base.searchsortedlast(v::Array, x::AbstractSIMDVector{W,I}, lo::T, hi::T, o::Base.Ordering) where {W,I,T<:Integer}
   u = convert(T, typeof(x)(1))
   lo = lo - u
   hi = hi + u
@@ -212,6 +212,6 @@ end
   end
   return lo
 end
-@inline function Base.searchsortedlast(v::AbstractVector, x::VecUnroll, lo::T, hi::T, o::Base.Ordering) where {T<:Integer} 
+@inline function Base.searchsortedlast(v::Array, x::VecUnroll, lo::T, hi::T, o::Base.Ordering) where {T<:Integer} 
   VecUnroll(fmap(searchsortedlast,v, data(x), lo, hi, o))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1047,6 +1047,9 @@ include("testsetup.jl")
     # for f ∈ [sqrt]
     #     @test tovector(f(vpos)) == map(f, tovector(vpos))
     # end
+
+    @test getindex([2,4,6,8],Vec(1,2,3,4)) === Vec(2,4,6,8)
+    @test searchsortedlast([1, 2, 4, 5, 5, 7], Vec(4,5,3,0)) === Vec(3,5,2,0)
   end
   println("Binary Functions")
   @time @testset "Binary Functions" begin
@@ -1338,9 +1341,6 @@ include("testsetup.jl")
 
       @test gcd(Vec(42, 64, 0, -37), Vec(18, 96, -38, 0)) === Vec(6, 32, 38, 37)
       @test lcm(Vec(24, 16, 42, 0), Vec(18, 12, 18, 17)) === Vec(72, 48, 126, 0)
-
-      @test getindex([2,4,6,8],Vec(1,2,3,4)) === Vec(2,4,6,8)
-      @test searchsortedlast([1, 2, 4, 5, 5, 7], Vec(4,5,3,0)) === Vec(3,5,2,0)
     end
     if VectorizationBase.simd_integer_register_size() ≥ 16
       @test VecUnroll((

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1338,6 +1338,9 @@ include("testsetup.jl")
 
       @test gcd(Vec(42, 64, 0, -37), Vec(18, 96, -38, 0)) === Vec(6, 32, 38, 37)
       @test lcm(Vec(24, 16, 42, 0), Vec(18, 12, 18, 17)) === Vec(72, 48, 126, 0)
+
+      @test getindex([2,4,6,8],Vec(1,2,3,4)) === Vec(2,4,6,8)
+      @test searchsortedlast([1, 2, 4, 5, 5, 7], Vec(4,5,3,0)) === Vec(3,5,2,0)
     end
     if VectorizationBase.simd_integer_register_size() ≥ 16
       @test VecUnroll((


### PR DESCRIPTION
Hi,

this PR adds searchsortedlast and getindex to VectorizationBase as discussed in PumasAI/DataInterpolations.jl#123.
I did some minor refinements and some additional testing to verify, that the vectorized searchsortedlast gives the same result as the scalar version.

As you predicted, there were still method ambiguities for getindex and searchsortedlast. I got rid of these by defining these functions for `Array` instead of `AbstractArray`, which is sufficient for my use case. A more general solution would be nice, but I'm out of ideas on how to do that in a more elegant way.