### PR TITLE
Accept vectorized lo,hi arguments to searchsortedlast

### DIFF
--- a/src/special/misc.jl
+++ b/src/special/misc.jl
@@ -230,7 +230,7 @@ end
   lo::T,
   hi::T,
   o::Base.Ordering
-) where {W,I,T<:Integer}
+) where {W,I,T<:Union{Integer,AbstractSIMDVector{W,<:Integer}}}
   u = convert(T, typeof(x)(1))
   lo = lo - u
   hi = hi + u
@@ -252,4 +252,13 @@ end
   o::Base.Ordering
 ) where {T<:Integer}
   VecUnroll(fmap(searchsortedlast, v, data(x), lo, hi, o))
+end
+@inline function Base.searchsortedlast(
+  v::Array,
+  x::VecUnroll,
+  lo::VecUnroll,
+  hi::VecUnroll,
+  o::Base.Ordering
+)
+  VecUnroll(fmap(searchsortedlast, v, data(x), data(lo), data(hi), o))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1168,6 +1168,11 @@ include("testsetup.jl")
     @test getindex([2, 4, 6, 8], Vec(1, 2, 3, 4)) === Vec(2, 4, 6, 8)
     @test searchsortedlast([1, 2, 4, 5, 5, 7], Vec(4, 5, 3, 0)) ===
           Vec(3, 5, 2, 0)
+    @test searchsortedlast(
+      [1, 2, 4, 5, 5, 7], Vec(4, 5, 3, 0),
+      Vec(2, 2, 1, 1), Vec(4, 6, 3, 6),
+      Base.Order.Forward
+    ) === Vec(3, 5, 2, 0)
   end
   println("Binary Functions")
   @time @testset "Binary Functions" begin


### PR DESCRIPTION
The most common way to call `searchsortedlast` provides default values for these arguments, but it can be far more efficient to use them — which is something I need to do.