### PR TITLE
Add vectorized vany for 8 wide masks

### DIFF
--- a/src/llvm_intrin/masks.jl
+++ b/src/llvm_intrin/masks.jl
@@ -287,7 +287,7 @@ end
 end
 
 @inline function vany(m::AbstractMask)
-  _vany(m, has_feature(Val(:x86_64_avx512f)))
+  _vany(m, has_feature(Val(:x86_64_avx512f)) | (!has_feature(Val(:x86_64_avx))))
 end
 @inline function _vany(m::Mask{8}, ::False)
   x = reinterpret(Float32, sext(Vec{8, Int32}, m))


### PR DESCRIPTION
This produces the desired instructions when doing the comparison and the vany as discussed in https://github.com/JuliaSIMD/LoopVectorization.jl/issues/481. 

However, this produces worse instructions if we call vany on a mask that is not obtained by a comparison, I don't know how common this use case actually is.
`@code_native debuginfo=:none vany(Mask{8, UInt8}(UInt8(1)))` for the current implementation gives `cmpb    $0, (%rcx)` whereas the new implementation is
```asm
movabsq $.LCPI0_0, %rax
vpbroadcastb    (%rcx), %ymm1
vmovdqa (%rax), %ymm0
vpand   %ymm0, %ymm1, %ymm1
vpcmpeqd        %ymm0, %ymm1, %ymm0
vtestps %ymm0, %ymm0
```