### PR TITLE
Type-assert `vconvert`s to circumvent inference restriction on recursion

### DIFF
--- a/src/llvm_intrin/conversion.jl
+++ b/src/llvm_intrin/conversion.jl
@@ -69,13 +69,13 @@ if (Sys.ARCH === :x86_64) || (Sys.ARCH === :i686)
   @inline function vconvert(
     ::Type{Vec{W,F}},
     v::Vec{W,T}
-  ) where {W,F<:FloatingTypes,T<:IntegerTypesHW}
+  )::Vec{W,F} where {W,F<:FloatingTypes,T<:IntegerTypesHW}
     _vconvert(Vec{W,F}, v, True())
   end
   @inline function vconvert(
     ::Type{Vec{W,F}},
     v::Vec{W,T}
-  ) where {W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
+  )::Vec{W,F} where {W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
     _vconvert(
       Vec{W,F},
       v,
@@ -85,7 +85,7 @@ if (Sys.ARCH === :x86_64) || (Sys.ARCH === :i686)
   @inline function vconvert(
     ::Type{F},
     v::VecUnroll{N,W,T,Vec{W,T}}
-  ) where {N,W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
+  )::VecUnroll{N,W,F,Vec{W,F}} where {N,W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
     _vconvert(
       Vec{W,F},
       v,
@@ -95,7 +95,7 @@ if (Sys.ARCH === :x86_64) || (Sys.ARCH === :i686)
   @inline function vconvert(
     ::Type{Vec{W,F}},
     v::VecUnroll{N,W,T,Vec{W,T}}
-  ) where {N,W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
+  )::VecUnroll{N,W,F,Vec{W,F}} where {N,W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
     _vconvert(
       Vec{W,F},
       v,
@@ -105,7 +105,7 @@ if (Sys.ARCH === :x86_64) || (Sys.ARCH === :i686)
   @inline function vconvert(
     ::Type{VecUnroll{N,W,F,Vec{W,F}}},
     v::VecUnroll{N,W,T,Vec{W,T}}
-  ) where {N,W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
+  )::VecUnroll{N,W,F,Vec{W,F}} where {N,W,F<:FloatingTypes,T<:Union{UInt64,Int64}}
     _vconvert(
       Vec{W,F},
       v,
@@ -116,7 +116,7 @@ else
   @generated function vconvert(
     ::Type{Vec{W,F}},
     v::Vec{W,T}
-  ) where {W,F<:FloatingTypes,T<:IntegerTypesHW}
+  )::Vec{W,F} where {W,F<:FloatingTypes,T<:IntegerTypesHW}
     convert_func(T <: Signed ? "sitofp" : "uitofp", F, W, T)
   end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaSIMD/LoopVectorization.jl/issues/526, building upon @chriselrod's last commits a month or two ago, by type-asserting the return types of `vconvert` in the relevant cases.

Digging around with Cthuhlu's `@descend` I found that the issue, at least when I tested on 1.10.2, originates from the recursive calling of `_vconvert` in `promote` which caused the compiler to give up on inference (I assume this became more restrictive in 1.10).
Not sure if this solution is "legal" in the sense that `vconvert` always returns the type I annotated.

If this is fine, I would also add tests in LV's "test/" directory.

