### PR TITLE
Add `const` to misleading double assignment

### DIFF
--- a/src/llvm_intrin/memory_addr.jl
+++ b/src/llvm_intrin/memory_addr.jl
@@ -86,7 +86,7 @@ const STORE_SCOPE_FLAGS = ", !noalias !3";
 # !9 = !{!"jtbaa"}
 # """;
 # const TBAA_FLAGS = ", !tbaa !4";
-const TBAA_STR = TBAA_FLAGS = ""
+const TBAA_STR = const TBAA_FLAGS = ""
 # const TBAA_STR = """
 # !4 = !{!"jtbaa", !5, i64 0}
 # !5 = !{!"jtbaa"}


### PR DESCRIPTION
In `const a = b = ...`, only `a` ends up const, although the syntax is arguably confusing. I don't think it matters to much in this context, but TBAA_FLAGS was clearly intended to be const, so annotate it as such.