### PR TITLE
Resolve Aqua method ambiguity: convert(::Type{Static.{True,False,StaticInt{N}}}, ::LazyMulAdd)

### DIFF
--- a/src/lazymul.jl
+++ b/src/lazymul.jl
@@ -28,6 +28,25 @@ end
   ::Type{LazyMulAdd{M,O,I}},
   a::LazyMulAdd{M,O,I}
 ) where {M,O,I} = a
+# Disambiguate the generic `convert(::Type{T<:Number}, ::LazyMulAdd)` above
+# against Static.jl's `convert(::Type{Static.{True,False,StaticInt{N}}},
+# ::Number)` methods. Aqua flags both as matching `convert(Static.True,
+# ::LazyMulAdd)` etc., since `LazyMulAdd <: Number` and neither method is
+# strictly more specific. Forward to `Static`'s convert on the materialized
+# value so the StaticBool / StaticInt singletons come out, matching what
+# Static.jl produces for any Number input.
+@inline Base.convert(
+  ::Type{Static.True},
+  a::LazyMulAdd{M,O,I}
+) where {M,O,I} = convert(Static.True, _materialize(a))
+@inline Base.convert(
+  ::Type{Static.False},
+  a::LazyMulAdd{M,O,I}
+) where {M,O,I} = convert(Static.False, _materialize(a))
+@inline Base.convert(
+  ::Type{Static.StaticInt{N}},
+  a::LazyMulAdd{M,O,I}
+) where {M,O,I,N} = convert(Static.StaticInt{N}, _materialize(a))
 # @inline Base.convert(::Type{LazyMulAdd{M,O,I}}, a::LazyMulAdd{M}) where {M,O,I} = a
 # @inline Base.convert(::Type{LazyMulAdd{M,T,I}}, a::LazyMulAdd{M,StaticInt{O},I}) where {M,O,I,T} = a
 


### PR DESCRIPTION
## Summary

`Aqua.test_ambiguities([VectorizationBase])` currently fails (3 ambiguities) on master CI for every Julia × platform combo:

```
Ambiguity #1
convert(::Type{Static.True}, x::Number) @ Static .../Static.jl:465
convert(::Type{T}, a::VectorizationBase.LazyMulAdd{M, O, I}) where {M, O, I, T<:Number} @ VectorizationBase src/lazymul.jl:25

Ambiguity #2
convert(::Type{Static.StaticInt{N}}, x::Number) where N @ Static .../Static.jl:453
convert(::Type{T}, a::VectorizationBase.LazyMulAdd{M, O, I}) where {M, O, I, T<:Number} @ VectorizationBase src/lazymul.jl:25

Ambiguity #3
convert(::Type{Static.False}, x::Number) @ Static .../Static.jl:469
convert(::Type{T}, a::VectorizationBase.LazyMulAdd{M, O, I}) where {M, O, I, T<:Number} @ VectorizationBase src/lazymul.jl:25
```

Both sides match `convert(Static.True, ::LazyMulAdd)` etc.: Static constrains the first arg, VB constrains the second, neither is strictly more specific. Fix by adding the three Aqua-suggested overloads that constrain both args and forward to `Static`'s convert on `_materialize(a)`. This preserves the lazy-evaluation discipline of the generic `convert(::Type{T<:Number}, ::LazyMulAdd)` while letting Static.jl's value-assertion semantics apply to the result.

This isn't introduced by my in-flight macOS-ARM PRs (#127 and JuliaSIMD/LoopVectorization.jl#569) — last master CI from August 2025 was before the Static.jl / Aqua version bump that exposed it, so it's been latent on master since. Posting separately to keep #127 focused on the ARM grant work.

## Test plan

- [x] `Aqua.test_ambiguities([VectorizationBase])` passes locally on Apple M-series + Julia 1.11. (1/1, was 0/1.)
- [x] `convert(Static.StaticInt{5}, LazyMulAdd{5}(1)) === StaticInt{5}()` and `convert(Static.True, LazyMulAdd{1}(1)) === Static.True()` round-trip correctly.
- [ ] CI green for the ambiguity check on all Julia × platform combos.

Note: master CI also has a pre-existing `Piracy` Aqua check failure (long list of `==`/`<`/`muladd`/etc. methods this package defines on external types) — that's a separate hygiene concern, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)