### PR TITLE
Use vfma in TwoProduct paths of special/double.jl (fix SLEEFPirates accuracy regression)

### DIFF
--- a/src/special/double.jl
+++ b/src/special/double.jl
@@ -315,9 +315,19 @@ end
 end
 
 # two-prod-fma
+#
+# These `::True` branches implement the TwoProduct error-free transformation
+# (e.g. `Double(z, fma(x, y, -z))`), which extracts the rounding error of
+# `x*y` as the low part of a double-double. The identity requires a
+# **single-rounded** FMA; using the may-fuse `vfmsub`/`vfnmadd` lets LLVM
+# constant-fold `(x*y) + (-(x*y))` to `0` even on hardware that has FMA,
+# which destroys every double-double error term and propagates as wildly
+# wrong results in downstream `asinh`/`sin`/`cos`/etc. (e.g. ~10^5 ULP on
+# Float32). Call `vfma` (which lowers to `llvm.fma`) directly with an
+# explicit negation so the FMA is preserved.
 @inline function dmul(x::vIEEEFloat, y::vIEEEFloat, ::True)
   z = (x * y)
-  Double(z, vfmsub(x, y, z))
+  Double(z, vfma(x, y, -z))
 end
 @inline function dmul(x::vIEEEFloat, y::vIEEEFloat, ::False)
   hx, lx = splitprec(x)
@@ -329,7 +339,7 @@ end
 end
 @inline function dmul(x::Double{<:vIEEEFloat}, y::vIEEEFloat, ::True)
   z = (x.hi * y)
-  Double(z, vfmsub(x.hi, y, z) + x.lo * y)
+  Double(z, vfma(x.hi, y, -z) + x.lo * y)
 end
 @inline function dmul(x::Double{<:vIEEEFloat}, y::vIEEEFloat, ::False)
   hx, lx = splitprec(x.hi)
@@ -341,7 +351,7 @@ end
 end
 @inline function dmul(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat}, ::True)
   z = x.hi * y.hi
-  Double(z, vfmsub(x.hi, y.hi, z) + x.hi * y.lo + x.lo * y.hi)
+  Double(z, vfma(x.hi, y.hi, -z) + x.hi * y.lo + x.lo * y.hi)
 end
 @inline function dmul(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat}, ::False)
   hx, lx = splitprec(x.hi)
@@ -361,7 +371,7 @@ end
 # x^2
 @inline function dsqu(x::T, ::True) where {T<:vIEEEFloat}
   z = x * x
-  Double(z, vfmsub(x, x, z))
+  Double(z, vfma(x, x, -z))
 end
 @inline function dsqu(x::T, ::False) where {T<:vIEEEFloat}
   hx, lx = splitprec(x)
@@ -372,7 +382,7 @@ end
 end
 @inline function dsqu(x::Double{T}, ::True) where {T<:vIEEEFloat}
   z = x.hi * x.hi
-  Double(z, vfmsub(x.hi, x.hi, z) + (x.hi * (x.lo + x.lo)))
+  Double(z, vfma(x.hi, x.hi, -z) + (x.hi * (x.lo + x.lo)))
 end
 @inline function dsqu(x::Double{T}, ::False) where {T<:vIEEEFloat}
   hx, lx = splitprec(x.hi)
@@ -386,7 +396,7 @@ end
 # sqrt(x)
 @inline function dsqrt(x::Double{T}, ::True) where {T<:vIEEEFloat}
   zhi = @fastmath sqrt(x.hi)
-  Double(zhi, (x.lo + vfnmadd(zhi, zhi, x.hi)) / (zhi + zhi))
+  Double(zhi, (x.lo + vfma(-zhi, zhi, x.hi)) / (zhi + zhi))
 end
 @inline function dsqrt(x::Double{T}, ::False) where {T<:vIEEEFloat}
   c = @fastmath sqrt(x.hi)
@@ -399,7 +409,7 @@ end
 @inline function ddiv(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat}, ::True)
   invy = inv(y.hi)
   zhi = (x.hi * invy)
-  Double(zhi, ((vfnmadd(zhi, y.hi, x.hi) + vfnmadd(zhi, y.lo, x.lo)) * invy))
+  Double(zhi, ((vfma(-zhi, y.hi, x.hi) + vfma(-zhi, y.lo, x.lo)) * invy))
 end
 @inline function ddiv(x::Double{<:vIEEEFloat}, y::Double{<:vIEEEFloat}, ::False)
   @ieee begin
@@ -412,7 +422,7 @@ end
 @inline function ddiv(x::vIEEEFloat, y::vIEEEFloat, ::True)
   ry = inv(y)
   r = (x * ry)
-  Double(r, (vfnmadd(r, y, x) * ry))
+  Double(r, (vfma(-r, y, x) * ry))
 end
 @inline function ddiv(x::vIEEEFloat, y::vIEEEFloat, ::False)
   @ieee begin
@@ -427,7 +437,7 @@ end
 # 1/x
 @inline function drec(x::vIEEEFloat, ::True)
   zhi = inv(x)
-  Double(zhi, (vfnmadd(zhi, x, one(eltype(x))) * zhi))
+  Double(zhi, (vfma(-zhi, x, one(eltype(x))) * zhi))
 end
 @inline function drec(x::vIEEEFloat, ::False)
   @ieee begin
@@ -439,7 +449,7 @@ end
 
 @inline function drec(x::Double{<:vIEEEFloat}, ::True)
   zhi = inv(x.hi)
-  Double(zhi, ((vfnmadd(zhi, x.hi, one(eltype(x))) - (zhi * x.lo)) * zhi))
+  Double(zhi, ((vfma(-zhi, x.hi, one(eltype(x))) - (zhi * x.lo)) * zhi))
 end
 @inline function drec(x::Double{<:vIEEEFloat}, ::False)
   @ieee begin


### PR DESCRIPTION
## Summary

The `::True` branches of `dmul`, `dsqu`, `dsqrt`, `ddiv`, `drec` in `src/special/double.jl` implement the TwoProduct error-free transformation:

```julia
z = x * y
Double(z, fma(x, y, -z))   # the second arg is the rounding error of x*y
```

That identity **requires** a single-rounded FMA. The code was calling the `vfmsub` / `vfnmadd` family, which (by design) lowers to `llvm.fmuladd`. `llvm.fmuladd` is permitted by LLVM's middle-end to algebraically fold `(x*y) + (-(x*y)) → 0` regardless of whether the target has hardware FMA — and that's exactly what happens. The result is that every double-double error term in `special/double.jl` was being silently destroyed.

Symptom: catastrophic precision loss in SLEEFPirates' transcendentals that go through double-double — `SLEEFPirates.asinh(-959.98f0)` returned ≈ `-7.62` instead of ≈ `-7.56006` (~10⁵ ULP). `sin`, `cos`, `tan`, `acos`, `asin`, `cos_sincos`, `sin_sincos` all fail SLEEFPirates' Float32 accuracy tests for the same reason.

## Fix

Switch the 10 TwoProduct call sites in `src/special/double.jl` to `vfma` (which lowers to `llvm.fma`, where LLVM cannot apply the algebraic-simplification that destroys the error term).

The `vfmadd` / `vfmsub` / `vfnmadd` / `vfnmsub` family is **not** changed. The "may-fuse" contract on those functions is correct for the perf-oriented callers it serves throughout LV / VB (they're equivalent to a single FMA on hardware-FMA targets and to a fast separate mul+add on pre-FMA targets — which is exactly the right tradeoff for code that doesn't need TwoProduct semantics). Only the 10 callers that actually rely on guaranteed single-rounded FMA are switched.

This makes the design clearer too:
- **`vfmadd` family** = "compute `a·b + c` with whatever's fastest; you don't get FMA semantics" — for normal arithmetic.
- **`vfma`** = "guaranteed single-rounded FMA" — for TwoProduct / Kahan / compensated arithmetic / anything that depends on rounding.

## Background

The `vfmadd` family was conditional (`fma_fast() ? vfma : vmuladd`) until commit fed35e8 (Aug 2022, "avoid fma for vfmadd"), which collapsed it to always `vmuladd`. That was deliberate for perf on no-FMA targets — but the callers in `special/double.jl` were calling `vfmadd` family functions intending FMA semantics, which was a latent bug in the callers, not the dispatch. Fixing the callers is the right scope.

## Test plan

- [x] `SLEEFPirates.asinh(-959.98f0) == Base.asinh(-959.98f0)` to Float32 precision.
- [x] SLEEFPirates accuracy suite locally on Apple M-series: 560 pass / 1 fail (`tanh_fast` 1-ULP edge, separate issue) / 4 broken (pre-existing `pow_fast`). Was many fails (`asinh`, `sin`, `cos`, `tan`, `asin`, `acos`, `cos_sincos`, `sin_sincos`).
- [x] LoopVectorization `dot.jl` (171/171) and `gemm.jl` (18137/18137) pass — no regression.
- [ ] CI green for `SLEEFPirates.jl/Interface/*` downstream jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)