### PR TITLE
CI: lts/1/pre/nightly matrix; soft-fail on pre/nightly; native arch per OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'pre' || matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -18,12 +19,21 @@ jobs:
           - 'lts'
           - '1'
           - 'pre'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
+        include:
+          # Native arch per OS. `macOS-latest` is Apple silicon since the
+          # 2024 GitHub Actions image refresh; forcing `arch: x64` there
+          # would run Julia under Rosetta emulation.
+          - os: ubuntu-latest
+            arch: x64
+          - os: macOS-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -43,9 +53,10 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/cix86.yml
+++ b/.github/workflows/cix86.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'pre' || matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -18,6 +19,7 @@ jobs:
           - 'lts'
           - '1'
           - 'pre'
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:
@@ -41,9 +43,10 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Match the CI shape adopted in JuliaSIMD/LoopVectorization.jl#571 and JuliaSIMD/SLEEFPirates.jl (#46 + #49):

- Add `nightly` to the matrix alongside the existing `lts` / `1` / `pre`.
- `continue-on-error: true` on `pre` and `nightly` so recurring upstream Julia incompat (`OncePerThread` `MethodError`, etc.) surfaces in the status panel without blocking PRs.
- macOS-latest switches to native `aarch64` via a per-OS `include:` block (it's Apple silicon since the 2024 GitHub Actions image refresh; the previous `arch: x64` ran Julia under Rosetta and produced measurable FP-rounding noise on downstream math tests).
- Bump `codecov/codecov-action` v3 → v5 (v3 is EOL; `file:` → `files:`).

Floor stays at `julia = "1.10"` in `Project.toml` (current Julia LTS); no source changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)